### PR TITLE
Fixes typo in RPC example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ RPC via connector:
 
 ```
 POST /services/something.SomethingService/List
-REQUEST PROTO: SomethingReqest.new(param: 'one')
+REQUEST PROTO: SomethingRequest.new(param: 'one')
 RESPONSE PROTO: SomethingResponse.new(some: 'output')
 ```
 


### PR DESCRIPTION
Noticed a typo as I was reading through the README.
