### PR TITLE
Drop logging in Rough

### DIFF
--- a/lib/rough/base_controller.rb
+++ b/lib/rough/base_controller.rb
@@ -10,7 +10,6 @@ module Rough
 
     def self.included(base)
       base.class_eval do
-        before_action :log_proto, if: :rpc?
         alias_method_chain :params, :request_proto
       end
     end
@@ -58,10 +57,6 @@ module Rough
 
     def rpc?
       rpc_name
-    end
-
-    def log_proto
-      Rails.logger.info("  Request Proto: #{request_proto.inspect}")
     end
 
     def rpc_name

--- a/lib/rough/version.rb
+++ b/lib/rough/version.rb
@@ -1,3 +1,3 @@
 module Rough
-  VERSION = '0.2.6'
+  VERSION = '0.2.7'
 end

--- a/spec/examples/base_controller_spec.rb
+++ b/spec/examples/base_controller_spec.rb
@@ -32,11 +32,6 @@ describe TestController, type: :request do
         expect(response.status).to eq(TestController::STATUS)
       end
 
-      it 'should log the request proto' do
-        rp = FakeRequestProto.new({ name: 'john', rpc: 'Fake#fake', action: 'test', controller: 'test' }.stringify_keys)
-        expect(Rails.logger).to have_received(:info).with("  Request Proto: #{rp.inspect}")
-      end
-
       it 'should respond with json' do
         expect(response.content_type).to eq('application/json')
       end
@@ -46,7 +41,6 @@ describe TestController, type: :request do
     context 'and called over json' do
 
       before do
-        allow(Rails.logger).to receive(:info)
         post '/test-rpc', {
           name: 'john'
         }.to_json, 'Content-Type' => 'application/json', 'Accept' => 'application/json'
@@ -54,11 +48,6 @@ describe TestController, type: :request do
 
       it 'should pass back the response status' do
         expect(response.status).to eq(TestController::STATUS)
-      end
-
-      it 'should log the request proto' do
-        rp = FakeRequestProto.new({ name: 'john', rpc: 'Fake#fake', action: 'test', controller: 'test' }.stringify_keys)
-        expect(Rails.logger).to have_received(:info).with("  Request Proto: #{rp.inspect}")
       end
 
       it 'should respond with json' do
@@ -74,7 +63,6 @@ describe TestController, type: :request do
       let(:mime) { Rough::BaseController::PROTO_MIME.to_s }
 
       before do
-        allow(Rails.logger).to receive(:info)
         post '/test-rpc', echo_request.encode, 'Content-Type' => mime, 'Accept' => mime
       end
 
@@ -120,17 +108,11 @@ describe TestController, type: :request do
   context 'when the route is not rpc' do
 
     before do
-      allow(Rails.logger).to receive(:info)
       post '/test-not-rpc', name: 'john'
     end
 
     it 'should pass back the response status' do
       expect(response.status).to eq(TestController::STATUS)
-    end
-
-    it 'should not log the request proto' do
-      rp = OpenStruct.new(name: 'john', rpc: 'Fake#fake', action: 'test', controller: 'test')
-      expect(Rails.logger).not_to have_received(:info).with("  Request Proto: #{rp.inspect}")
     end
 
   end


### PR DESCRIPTION
Logging the entire proto can cause us to drop hundreds of KBs or MBs of protos when requests are big. While it shouldn't log PII, because we respect redaction, it also requires people to tag their fields properly.